### PR TITLE
fix: Handle Special Case for Editing Lockable Text Field

### DIFF
--- a/step3.2-textFieldsChallengeApp-solution/TextFieldChallengeApps/ViewController.swift
+++ b/step3.2-textFieldsChallengeApp-solution/TextFieldChallengeApps/ViewController.swift
@@ -37,7 +37,12 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
     
     // MARK: Text Field Delegate
-
+    // Prevent editing when text field is already selected prior to toggling switch
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let isEditable = self.editingSwitch.isOn ? true : false
+        return isEditable
+    }
+    
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         return self.editingSwitch.isOn
     }


### PR DESCRIPTION
Need to implement textField(_:shouldChangeCharactersIn:replacementString:) to handle special case for editing text field. User could previously turn on switch, start editing, turn off switch, and continue editing.